### PR TITLE
Add basic restaurant app prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Posting Data from PhoneGap
+
+This repository originally contained an example of posting data from a PhoneGap app to a PHP backend.
+
+## New Prototype
+
+A minimal restaurant ordering prototype has been added in the `restaurant-app` folder. It demonstrates a React Native mobile app and a simple React-based admin panel.
+
+The prototype is not a production-ready solution but serves as a starting point for a more complete ordering system.

--- a/restaurant-app/admin-panel/package.json
+++ b/restaurant-app/admin-panel/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "restaurant-admin-panel",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.js",
+  "dependencies": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "scripts": {
+    "start": "serve public"
+  }
+}

--- a/restaurant-app/admin-panel/public/index.html
+++ b/restaurant-app/admin-panel/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Restaurant Admin Panel</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="../src/index.js"></script>
+</body>
+</html>

--- a/restaurant-app/admin-panel/src/index.js
+++ b/restaurant-app/admin-panel/src/index.js
@@ -1,0 +1,2 @@
+const root = document.getElementById('root');
+root.innerHTML = '<h1>Restaurant Admin Panel</h1><p>Manage menu and orders here.</p>';

--- a/restaurant-app/docs/DESIGN.md
+++ b/restaurant-app/docs/DESIGN.md
@@ -1,0 +1,18 @@
+# Restaurant Ordering App Design
+
+This folder contains a lightweight prototype for a restaurant ordering system.
+The mobile app is built with React Native/Expo while the admin panel uses basic React.
+
+## Mobile App
+- Browse a simple menu
+- Add items to a cart
+- Remove items from the cart
+- Placeholder checkout button
+
+## Admin Panel
+- Simple web page placeholder
+- Intended for managing menu items and viewing orders
+
+This repo includes only a minimal prototype. Additional features like authentication,
+real payment processing, and order tracking would need to be implemented
+before using in production.

--- a/restaurant-app/mobile-app/App.js
+++ b/restaurant-app/mobile-app/App.js
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { SafeAreaView, View, Text, Button, FlatList, TouchableOpacity } from 'react-native';
+
+const MENU = [
+  { id: '1', name: 'Margherita Pizza', price: 12.99 },
+  { id: '2', name: 'Chicken Burger', price: 10.49 },
+  { id: '3', name: 'Caesar Salad', price: 8.99 }
+];
+
+export default function App() {
+  const [cart, setCart] = useState([]);
+
+  const addToCart = (item) => {
+    setCart([...cart, item]);
+  };
+
+  const removeFromCart = (index) => {
+    const newCart = [...cart];
+    newCart.splice(index, 1);
+    setCart(newCart);
+  };
+
+  const renderItem = ({ item }) => (
+    <TouchableOpacity onPress={() => addToCart(item)} style={{ padding: 16, borderBottomWidth: 1 }}>
+      <Text style={{ fontSize: 18 }}>{item.name} - ${item.price.toFixed(2)}</Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <SafeAreaView style={{ flex: 1, justifyContent: 'center' }}>
+      <View style={{ flex: 2 }}>
+        <Text style={{ fontSize: 24, fontWeight: 'bold', textAlign: 'center', marginBottom: 10 }}>Menu</Text>
+        <FlatList data={MENU} renderItem={renderItem} keyExtractor={(item) => item.id} />
+      </View>
+      <View style={{ flex: 1, borderTopWidth: 1, padding: 16 }}>
+        <Text style={{ fontSize: 20, fontWeight: 'bold' }}>Cart</Text>
+        {cart.map((item, index) => (
+          <View key={index} style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginVertical: 4 }}>
+            <Text>{item.name}</Text>
+            <Button title="Remove" onPress={() => removeFromCart(index)} />
+          </View>
+        ))}
+        <Button title="Checkout" onPress={() => {}} disabled={cart.length === 0} />
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/restaurant-app/mobile-app/package.json
+++ b/restaurant-app/mobile-app/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "restaurant-mobile-app",
+  "version": "0.1.0",
+  "private": true,
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.6"
+  }
+}


### PR DESCRIPTION
## Summary
- document new prototype in README
- add minimal design docs
- prototype mobile app in React Native/Expo
- stub admin panel with simple React page

## Testing
- `node --version`
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6872f4c7db84832fb0c0727e59883d7d